### PR TITLE
Update frameworks to latest

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -26,10 +26,10 @@ description: "Template App to quickly get up and running with the Shotgun Pipeli
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.14.28"
+requires_core_version: "v0.14.133"
 requires_engine_version:
 
 # the frameworks required to run this app
 frameworks:
-    - {"name": "tk-framework-shotgunutils", "version": "v2.x.x"}
-    - {"name": "tk-framework-qtwidgets", "version": "v1.x.x"}
+    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x"}
+    - {"name": "tk-framework-qtwidgets", "version": "v2.x.x"}

--- a/python/app/delegate_list_item.py
+++ b/python/app/delegate_list_item.py
@@ -15,7 +15,7 @@ from sgtk.platform.qt import QtCore, QtGui
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils",
                                                "shotgun_model")
 shotgun_view = sgtk.platform.import_framework("tk-framework-qtwidgets",
-                                              "shotgun_view")
+                                              "views")
 
 from .widget_list_item import ListItemWidget
 


### PR DESCRIPTION
While we were trying to build a Pearl Studio app based on this repo's shotgun_model_delegate branch, we noticed that the frameworks being used were old and also one of the python files was calling an older API. 

```
2018-03-29 09:37:12,821 [19384 ERROR sgtk.env.project.tk-desktop] 
App C:\Users\satish\code\tk-app-pearl-downloader failed to initialize. 
It will not be loaded: 
Cannot find module shotgun_view as part of C:\Users\satish\AppData\Roaming\Shotgun\bundle_cache\app_store\tk-framework-qtwidgets\v2.7.1\python!
```

```shotgun_view``` was refactored to views (as seen in the following commt)

https://github.com/shotgunsoftware/tk-framework-qtwidgets/commit/9cdda432d8087a56f5a782113e0d9b9104309b7e#diff-3a7ebfbcc20948589324a1db2f9b04d5

We would like to share this small fix so that future users will also benefit from this.